### PR TITLE
Add binary protocol/prepared statement support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ It's currently in production use on github.com.
 
 ## Limitations
 
-* Only supports the parts of the text protocol that are in common use. There's no support for the binary protocol or prepared statements
+* Only supports the parts of the text protocol that are in common use.
 
 * No support for `LOAD DATA INFILE` on local files
 

--- a/inc/trilogy/blocking.h
+++ b/inc/trilogy/blocking.h
@@ -160,4 +160,19 @@ int trilogy_ping(trilogy_conn_t *conn);
  */
 int trilogy_close(trilogy_conn_t *conn);
 
+int trilogy_stmt_prepare(trilogy_conn_t *conn, const char *stmt, size_t stmt_len, trilogy_stmt_t *stmt_out);
+
+int trilogy_stmt_execute(trilogy_conn_t *conn, trilogy_stmt_t *stmt, uint8_t flags, trilogy_binary_value_t *binds,
+                         uint64_t *column_count_out);
+
+int trilogy_stmt_bind_data(trilogy_conn_t *conn, trilogy_stmt_t *stmt, uint16_t param_num, uint8_t *data,
+                           size_t data_len);
+
+int trilogy_stmt_read_full_row(trilogy_conn_t *conn, trilogy_stmt_t *stmt, trilogy_column_packet_t *columns,
+                               trilogy_binary_value_t *values_out);
+
+int trilogy_stmt_reset(trilogy_conn_t *conn, trilogy_stmt_t *stmt);
+
+int trilogy_stmt_close(trilogy_conn_t *conn, trilogy_stmt_t *stmt);
+
 #endif

--- a/inc/trilogy/builder.h
+++ b/inc/trilogy/builder.h
@@ -105,6 +105,10 @@ int trilogy_builder_write_uint32(trilogy_builder_t *builder, uint32_t val);
  */
 int trilogy_builder_write_uint64(trilogy_builder_t *builder, uint64_t val);
 
+int trilogy_builder_write_float(trilogy_builder_t *builder, float val);
+
+int trilogy_builder_write_double(trilogy_builder_t *builder, double val);
+
 /* trilogy_builder_write_lenenc - Append a length-encoded integer to the packet
  * buffer.
  *

--- a/inc/trilogy/client.h
+++ b/inc/trilogy/client.h
@@ -543,4 +543,28 @@ int trilogy_close_recv(trilogy_conn_t *conn);
  */
 void trilogy_free(trilogy_conn_t *conn);
 
+int trilogy_stmt_prepare_send(trilogy_conn_t *conn, const char *stmt, size_t stmt_len);
+
+/* trilogy_stmt_t - The trilogy client's prepared statement type.
+ */
+typedef trilogy_stmt_ok_packet_t trilogy_stmt_t;
+
+int trilogy_stmt_prepare_recv(trilogy_conn_t *conn, trilogy_stmt_t *stmt_out);
+
+int trilogy_stmt_bind_data_send(trilogy_conn_t *conn, trilogy_stmt_t *stmt, uint16_t param_num, uint8_t *data,
+                                size_t data_len);
+
+int trilogy_stmt_execute_send(trilogy_conn_t *conn, trilogy_stmt_t *stmt, uint8_t flags, trilogy_binary_value_t *binds);
+
+int trilogy_stmt_execute_recv(trilogy_conn_t *conn, uint64_t *column_count_out);
+
+int trilogy_stmt_read_row(trilogy_conn_t *conn, trilogy_stmt_t *stmt, trilogy_column_packet_t *columns,
+                          trilogy_binary_value_t *values_out);
+
+int trilogy_stmt_reset_send(trilogy_conn_t *conn, trilogy_stmt_t *stmt);
+
+int trilogy_stmt_reset_recv(trilogy_conn_t *conn);
+
+int trilogy_stmt_close_send(trilogy_conn_t *conn, trilogy_stmt_t *stmt);
+
 #endif

--- a/inc/trilogy/error.h
+++ b/inc/trilogy/error.h
@@ -21,7 +21,8 @@
     XX(TRILOGY_OPENSSL_ERR, -16) /* check ERR_get_error() */                                                           \
     XX(TRILOGY_UNSUPPORTED, -17)                                                                                       \
     XX(TRILOGY_DNS_ERR, -18)                                                                                           \
-    XX(TRILOGY_AUTH_SWITCH, -19)
+    XX(TRILOGY_AUTH_SWITCH, -19)                                                                                       \
+    XX(TRILOGY_UNKNOWN_TYPE, -20)
 
 enum {
 #define XX(name, code) name = code,

--- a/inc/trilogy/protocol.h
+++ b/inc/trilogy/protocol.h
@@ -548,6 +548,13 @@ typedef struct {
 } trilogy_ok_packet_t;
 
 typedef struct {
+    uint32_t id;
+    uint16_t column_count;
+    uint16_t parameter_count;
+    uint16_t warning_count;
+} trilogy_stmt_ok_packet_t;
+
+typedef struct {
     uint16_t warning_count;
     uint16_t status_flags;
 } trilogy_eof_packet_t;
@@ -596,6 +603,127 @@ typedef struct {
     const void *data;
     size_t data_len;
 } trilogy_value_t;
+
+typedef struct {
+    bool is_null;
+
+    TRILOGY_TYPE_t type;
+
+    union {
+        double dbl;
+
+        int64_t int64;
+        uint64_t uint64;
+
+        float flt;
+
+        uint32_t uint32;
+        int32_t int32;
+
+        uint16_t uint16;
+        int16_t int16;
+
+        uint8_t uint8;
+        int8_t int8;
+
+        struct {
+            const void *data;
+            size_t len;
+        } str;
+
+        struct {
+            uint16_t year;
+            uint8_t month, day;
+            struct {
+                bool is_negative;
+                uint32_t days;
+                uint8_t hour, minute, second;
+                uint32_t micro_seconds;
+            } time;
+        } date;
+    } as;
+} trilogy_binary_value_t;
+
+/* trilogy_build_stmt_prepare_packet - Build a prepared statement prepare command packet.
+ *
+ * builder   - A pointer to a pre-initialized trilogy_builder_t.
+ * query     - The query string to be used by the prepared statement.
+ * query_len - The length of query in bytes.
+ *
+ * Return values:
+ *   TRILOGY_OK     - The packet was successfully built and written to the
+ *                    builder's internal buffer.
+ *   TRILOGY_SYSERR - A system error occurred, check errno.
+ */
+int trilogy_build_stmt_prepare_packet(trilogy_builder_t *builder, const char *sql, size_t sql_len);
+
+// Prepared statement flags
+typedef enum {
+    TRILOGY_CURSOR_TYPE_NO_CURSOR  = 0x00,
+    TRILOGY_CURSOR_TYPE_READ_ONLY  = 0x01,
+    TRILOGY_CURSOR_TYPE_FOR_UPDATE = 0x02,
+    TRILOGY_CURSOR_TYPE_SCROLLABLE = 0x04,
+    TRILOGY_CURSOR_TYPE_UNKNOWN
+} TRILOGY_STMT_FLAGS_t;
+
+/* trilogy_build_stmt_execute_packet - Build a prepared statement execute command packet.
+ *
+ * builder   - A pointer to a pre-initialized trilogy_builder_t.
+ * stmt_id   - The statement id for which to build the execute packet with.
+ * flags     - The flags (TRILOGY_STMT_FLAGS_t) to be used with this execute command packet.
+ * binds     - Pointer to an array of trilogy_binary_value_t's.
+ * num_binds - The number of elements in the binds array above.
+ *
+ * Return values:
+ *   TRILOGY_OK                 - The packet was successfully built and written to the
+ *                                builder's internal buffer.
+ *   TRILOGY_PROTOCOL_VIOLATION - num_binds is > 0 but binds is NULL.
+ *   TRILOGY_UNKNOWN_TYPE       - An unsupported or unknown MySQL type was used in the list
+ *                                of binds.
+ *   TRILOGY_SYSERR             - A system error occurred, check errno.
+ */
+int trilogy_build_stmt_execute_packet(trilogy_builder_t *builder, uint32_t stmt_id, uint8_t flags,
+                                      trilogy_binary_value_t *binds, uint16_t num_binds);
+
+/* trilogy_build_stmt_bind_data_packet - Build a prepared statement send long data command packet.
+ *
+ * builder  - A pointer to a pre-initialized trilogy_builder_t.
+ * stmt_id  - The statement id for which to build the bind data packet with.
+ * param_id - The parameter index for which the supplied data should be bound to.
+ * data     - A pointer to the buffer containing the data to be bound.
+ * data_len - The length of the data buffer.
+ *
+ * Return values:
+ *   TRILOGY_OK     - The packet was successfully built and written to the
+ *                    builder's internal buffer.
+ *   TRILOGY_SYSERR - A system error occurred, check errno.
+ */
+int trilogy_build_stmt_bind_data_packet(trilogy_builder_t *builder, uint32_t stmt_id, uint16_t param_id, uint8_t *data,
+                                        size_t data_len);
+
+/* trilogy_build_stmt_reset_packet - Build a prepared statement reset command packet.
+ *
+ * builder - A pointer to a pre-initialized trilogy_builder_t.
+ * stmt_id - The statement id for which to build the reset packet with.
+ *
+ * Return values:
+ *   TRILOGY_OK     - The packet was successfully built and written to the
+ *                    builder's internal buffer.
+ *   TRILOGY_SYSERR - A system error occurred, check errno.
+ */
+int trilogy_build_stmt_reset_packet(trilogy_builder_t *builder, uint32_t stmt_id);
+
+/* trilogy_build_stmt_close_packet - Build a prepared statement close command packet.
+ *
+ * builder - A pointer to a pre-initialized trilogy_builder_t.
+ * stmt_id - The statement id for which to build the close packet with.
+ *
+ * Return values:
+ *   TRILOGY_OK     - The packet was successfully built and written to the
+ *                    builder's internal buffer.
+ *   TRILOGY_SYSERR - A system error occurred, check errno.
+ */
+int trilogy_build_stmt_close_packet(trilogy_builder_t *builder, uint32_t stmt_id);
 
 /* The following parsing functions assume the buffer and length passed in point
  * to one full MySQL-compatible packet. If the buffer contains more than one packet or
@@ -752,5 +880,49 @@ int trilogy_parse_column_packet(const uint8_t *buff, size_t len, bool field_list
  *                                  buffer.
  */
 int trilogy_parse_row_packet(const uint8_t *buff, size_t len, uint64_t column_count, trilogy_value_t *out_values);
+
+/* trilogy_parse_stmt_ok_packet - Parse a prepared statement ok packet.
+ *
+ * buff         - A pointer to the buffer containing the result packet data.
+ * len          - The length of buffer in bytes.
+ * out_packet   - Out parameter; A pointer to a pre-allocated trilogy_stmt_ok_packet_t.
+ *
+ * Return values:
+ *   TRILOGY_OK                   - The packet was was parsed and the out
+ *                                  parameter has been filled in.
+ *   TRILOGY_TRUNCATED_PACKET     - There isn't enough data in the buffer
+ *                                  to parse the packet.
+ *   TRILOGY_PROTOCOL_VIOLATION   - Filler byte was something other than zero.
+ *   TRILOGY_EXTRA_DATA_IN_PACKET - There are unparsed bytes left in the
+ *                                  buffer.
+ */
+int trilogy_parse_stmt_ok_packet(const uint8_t *buff, size_t len, trilogy_stmt_ok_packet_t *out_packet);
+
+/* trilogy_parse_stmt_row_packet - Parse a prepared statement row packet.
+ *
+ * buff         - A pointer to the buffer containing the result packet data.
+ * len          - The length of buffer in bytes.
+ * columns      - The list of columns from the prepared statement. This parser needs
+ *                this in order to match up the value types.
+ * column_count - The number of columns in prepared statement. This parser needs this
+ *                in order to know how many values to parse.
+ * out_values   - Out parameter; A pointer to a pre-allocated array of
+ *                trilogy_binary_value_t's. There must be enough space to fit all of the
+ *                values. This can be computed with:
+ *                `(sizeof(trilogy_value_t) * column_count)`.
+ *
+ * Return values:
+ *   TRILOGY_OK                   - The packet was was parsed and the out
+ *                                  parameter has been filled in.
+ *   TRILOGY_TRUNCATED_PACKET     - There isn't enough data in the buffer
+ *                                  to parse the packet.
+ *   TRILOGY_PROTOCOL_VIOLATION   - Invalid length parsed for a TIME/DATETIME/TIMESTAMP value.
+ *   TRILOGY_UNKNOWN_TYPE         - An unsupported or unknown MySQL type was used in the list
+ *                                  of binds.
+ *   TRILOGY_EXTRA_DATA_IN_PACKET - There are unparsed bytes left in the
+ *                                  buffer.
+ */
+int trilogy_parse_stmt_row_packet(const uint8_t *buff, size_t len, trilogy_column_packet_t *columns,
+                                  uint64_t column_count, trilogy_binary_value_t *out_values);
 
 #endif

--- a/inc/trilogy/reader.h
+++ b/inc/trilogy/reader.h
@@ -90,6 +90,10 @@ int trilogy_reader_get_uint32(trilogy_reader_t *reader, uint32_t *out);
  */
 int trilogy_reader_get_uint64(trilogy_reader_t *reader, uint64_t *out);
 
+int trilogy_reader_get_float(trilogy_reader_t *reader, float *out);
+
+int trilogy_reader_get_double(trilogy_reader_t *reader, double *out);
+
 /* trilogy_reader_get_lenenc - Parse an unsigned, length-encoded integer.
  *
  * reader - A pointer to a pre-initialized trilogy_reader_t.

--- a/src/blocking.c
+++ b/src/blocking.c
@@ -238,4 +238,121 @@ int trilogy_close(trilogy_conn_t *conn)
     }
 }
 
+int trilogy_stmt_prepare(trilogy_conn_t *conn, const char *stmt, size_t stmt_len, trilogy_stmt_t *stmt_out)
+{
+    int rc = trilogy_stmt_prepare_send(conn, stmt, stmt_len);
+
+    if (rc == TRILOGY_AGAIN) {
+        rc = flush_full(conn);
+    }
+
+    if (rc < 0) {
+        return rc;
+    }
+
+    while (1) {
+        rc = trilogy_stmt_prepare_recv(conn, stmt_out);
+
+        if (rc != TRILOGY_AGAIN) {
+            return rc;
+        }
+
+        CHECKED(trilogy_sock_wait_read(conn->socket));
+    }
+}
+
+int trilogy_stmt_execute(trilogy_conn_t *conn, trilogy_stmt_t *stmt, uint8_t flags, trilogy_binary_value_t *binds,
+                         uint64_t *column_count_out)
+{
+    int rc = trilogy_stmt_execute_send(conn, stmt, flags, binds);
+
+    if (rc == TRILOGY_AGAIN) {
+        rc = flush_full(conn);
+    }
+
+    if (rc < 0) {
+        return rc;
+    }
+
+    while (1) {
+        rc = trilogy_stmt_execute_recv(conn, column_count_out);
+
+        if (rc != TRILOGY_AGAIN) {
+            return rc;
+        }
+
+        CHECKED(trilogy_sock_wait_read(conn->socket));
+    }
+}
+
+int trilogy_stmt_bind_data(trilogy_conn_t *conn, trilogy_stmt_t *stmt, uint16_t param_num, uint8_t *data,
+                           size_t data_len)
+{
+    int rc = trilogy_stmt_bind_data_send(conn, stmt, param_num, data, data_len);
+
+    if (rc == TRILOGY_AGAIN) {
+        rc = flush_full(conn);
+    }
+
+    if (rc < 0) {
+        return rc;
+    }
+
+    return TRILOGY_OK;
+}
+
+int trilogy_stmt_read_full_row(trilogy_conn_t *conn, trilogy_stmt_t *stmt, trilogy_column_packet_t *columns,
+                               trilogy_binary_value_t *values_out)
+{
+    int rc;
+
+    while (1) {
+        rc = trilogy_stmt_read_row(conn, stmt, columns, values_out);
+
+        if (rc != TRILOGY_AGAIN) {
+            return rc;
+        }
+
+        CHECKED(trilogy_sock_wait_read(conn->socket));
+    }
+}
+
+int trilogy_stmt_reset(trilogy_conn_t *conn, trilogy_stmt_t *stmt)
+{
+    int rc = trilogy_stmt_reset_send(conn, stmt);
+
+    if (rc == TRILOGY_AGAIN) {
+        rc = flush_full(conn);
+    }
+
+    if (rc < 0) {
+        return rc;
+    }
+
+    while (1) {
+        rc = trilogy_stmt_reset_recv(conn);
+
+        if (rc != TRILOGY_AGAIN) {
+            return rc;
+        }
+
+        CHECKED(trilogy_sock_wait_read(conn->socket));
+    }
+}
+
+int trilogy_stmt_close(trilogy_conn_t *conn, trilogy_stmt_t *stmt)
+{
+    int rc = trilogy_stmt_close_send(conn, stmt);
+
+    if (rc == TRILOGY_AGAIN) {
+        rc = flush_full(conn);
+    }
+
+    if (rc < 0) {
+        return rc;
+    }
+
+    return TRILOGY_OK;
+}
+
 #undef CHECKED

--- a/src/builder.c
+++ b/src/builder.c
@@ -113,6 +113,48 @@ int trilogy_builder_write_uint64(trilogy_builder_t *builder, uint64_t val)
     return TRILOGY_OK;
 }
 
+typedef union {
+    float f;
+    uint32_t u;
+} trilogy_float_buf_t;
+
+int trilogy_builder_write_float(trilogy_builder_t *builder, float val)
+{
+    trilogy_float_buf_t float_val;
+
+    float_val.f = val;
+
+    CHECKED(trilogy_builder_write_uint8(builder, float_val.u & 0xff));
+    CHECKED(trilogy_builder_write_uint8(builder, (float_val.u >> 8) & 0xff));
+    CHECKED(trilogy_builder_write_uint8(builder, (float_val.u >> 16) & 0xff));
+    CHECKED(trilogy_builder_write_uint8(builder, (float_val.u >> 24) & 0xff));
+
+    return TRILOGY_OK;
+}
+
+typedef union {
+    double d;
+    uint64_t u;
+} trilogy_double_buf_t;
+
+int trilogy_builder_write_double(trilogy_builder_t *builder, double val)
+{
+    trilogy_double_buf_t double_val;
+
+    double_val.d = val;
+
+    CHECKED(trilogy_builder_write_uint8(builder, double_val.u & 0xff));
+    CHECKED(trilogy_builder_write_uint8(builder, (double_val.u >> 8) & 0xff));
+    CHECKED(trilogy_builder_write_uint8(builder, (double_val.u >> 16) & 0xff));
+    CHECKED(trilogy_builder_write_uint8(builder, (double_val.u >> 24) & 0xff));
+    CHECKED(trilogy_builder_write_uint8(builder, (double_val.u >> 32) & 0xff));
+    CHECKED(trilogy_builder_write_uint8(builder, (double_val.u >> 40) & 0xff));
+    CHECKED(trilogy_builder_write_uint8(builder, (double_val.u >> 48) & 0xff));
+    CHECKED(trilogy_builder_write_uint8(builder, (double_val.u >> 56) & 0xff));
+
+    return TRILOGY_OK;
+}
+
 int trilogy_builder_write_lenenc(trilogy_builder_t *builder, uint64_t val)
 {
     if (val < 251) {

--- a/src/client.c
+++ b/src/client.c
@@ -725,4 +725,182 @@ void trilogy_free(trilogy_conn_t *conn)
     trilogy_buffer_free(&conn->packet_buffer);
 }
 
+int trilogy_stmt_prepare_send(trilogy_conn_t *conn, const char *stmt, size_t stmt_len)
+{
+    trilogy_builder_t builder;
+    int err = begin_command_phase(&builder, conn, 0);
+    if (err < 0) {
+        return err;
+    }
+
+    err = trilogy_build_stmt_prepare_packet(&builder, stmt, stmt_len);
+    if (err < 0) {
+        return err;
+    }
+
+    return begin_write(conn);
+}
+
+int trilogy_stmt_prepare_recv(trilogy_conn_t *conn, trilogy_stmt_t *stmt_out)
+{
+    int err = read_packet(conn);
+
+    if (err < 0) {
+        return err;
+    }
+
+    switch (current_packet_type(conn)) {
+    case TRILOGY_PACKET_OK: {
+        err = trilogy_parse_stmt_ok_packet(conn->packet_buffer.buff, conn->packet_buffer.len, stmt_out);
+
+        if (err < 0) {
+            return err;
+        }
+
+        conn->warning_count = stmt_out->warning_count;
+
+        return TRILOGY_OK;
+    }
+
+    case TRILOGY_PACKET_ERR:
+        return read_err_packet(conn);
+
+    default:
+        return TRILOGY_UNEXPECTED_PACKET;
+    }
+}
+
+int trilogy_stmt_execute_send(trilogy_conn_t *conn, trilogy_stmt_t *stmt, uint8_t flags, trilogy_binary_value_t *binds)
+{
+    trilogy_builder_t builder;
+    int err = begin_command_phase(&builder, conn, 0);
+    if (err < 0) {
+        return err;
+    }
+
+    err = trilogy_build_stmt_execute_packet(&builder, stmt->id, flags, binds, stmt->parameter_count);
+
+    if (err < 0) {
+        return err;
+    }
+
+    conn->packet_parser.sequence_number = builder.seq;
+
+    return begin_write(conn);
+}
+
+int trilogy_stmt_execute_recv(trilogy_conn_t *conn, uint64_t *column_count_out)
+{
+    int err = read_packet(conn);
+
+    if (err < 0) {
+        return err;
+    }
+
+    switch (current_packet_type(conn)) {
+    case TRILOGY_PACKET_OK:
+        return read_ok_packet(conn);
+
+    case TRILOGY_PACKET_ERR:
+        return read_err_packet(conn);
+
+    default: {
+        trilogy_result_packet_t result_packet;
+        err = trilogy_parse_result_packet(conn->packet_buffer.buff, conn->packet_buffer.len, &result_packet);
+
+        if (err < 0) {
+            return err;
+        }
+
+        conn->column_count = result_packet.column_count;
+        *column_count_out = result_packet.column_count;
+
+        return TRILOGY_OK;
+    }
+    }
+}
+
+// FYI: there is no `trilogy_stmt_bind_data_recv` because the server doesn't send a response.
+int trilogy_stmt_bind_data_send(trilogy_conn_t *conn, trilogy_stmt_t *stmt, uint16_t param_num, uint8_t *data,
+                                size_t data_len)
+{
+    trilogy_builder_t builder;
+    int err = begin_command_phase(&builder, conn, 0);
+    if (err < 0) {
+        return err;
+    }
+
+    err = trilogy_build_stmt_bind_data_packet(&builder, stmt->id, param_num, data, data_len);
+
+    if (err < 0) {
+        return err;
+    }
+
+    return begin_write(conn);
+}
+
+int trilogy_stmt_read_row(trilogy_conn_t *conn, trilogy_stmt_t *stmt, trilogy_column_packet_t *columns,
+                          trilogy_binary_value_t *values_out)
+{
+    int err = read_packet(conn);
+
+    if (err < 0) {
+        return err;
+    }
+
+    if (conn->capabilities & TRILOGY_CAPABILITIES_DEPRECATE_EOF && current_packet_type(conn) == TRILOGY_PACKET_EOF) {
+        if ((err = read_ok_packet(conn)) != TRILOGY_OK) {
+            return err;
+        }
+
+        return TRILOGY_EOF;
+    } else if (current_packet_type(conn) == TRILOGY_PACKET_EOF && conn->packet_buffer.len < 9) {
+        return read_eof_packet(conn);
+    } else if (current_packet_type(conn) == TRILOGY_PACKET_ERR) {
+        return read_err_packet(conn);
+    } else {
+        return trilogy_parse_stmt_row_packet(conn->packet_buffer.buff, conn->packet_buffer.len, columns,
+                                             stmt->column_count, values_out);
+    }
+}
+
+int trilogy_stmt_reset_send(trilogy_conn_t *conn, trilogy_stmt_t *stmt)
+{
+    int err = 0;
+
+    trilogy_builder_t builder;
+    err = begin_command_phase(&builder, conn, 0);
+    if (err < 0) {
+        return err;
+    }
+
+    err = trilogy_build_stmt_reset_packet(&builder, stmt->id);
+    if (err < 0) {
+        return err;
+    }
+
+    return begin_write(conn);
+}
+
+int trilogy_stmt_reset_recv(trilogy_conn_t *conn) {
+    return read_generic_response(conn);
+}
+
+int trilogy_stmt_close_send(trilogy_conn_t *conn, trilogy_stmt_t *stmt)
+{
+    trilogy_builder_t builder;
+    int err = begin_command_phase(&builder, conn, 0);
+    if (err < 0) {
+        return err;
+    }
+
+    err = trilogy_build_stmt_close_packet(&builder, stmt->id);
+
+    if (err < 0) {
+        return err;
+    }
+
+    return begin_write(conn);
+}
+
 #undef CHECKED

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -11,6 +11,12 @@
 #define TRILOGY_CMD_QUERY 0x03
 #define TRILOGY_CMD_PING 0x0e
 
+#define TRILOGY_CMD_STMT_PREPARE 0x16
+#define TRILOGY_CMD_STMT_EXECUTE 0x17
+#define TRILOGY_CMD_STMT_SEND_LONG_DATA 0x18
+#define TRILOGY_CMD_STMT_CLOSE 0x19
+#define TRILOGY_CMD_STMT_RESET 0x1a
+
 #define SCRAMBLE_LEN 20
 
 static size_t min(size_t a, size_t b)
@@ -401,6 +407,37 @@ fail:
     return rc;
 }
 
+int trilogy_parse_stmt_ok_packet(const uint8_t *buff, size_t len, trilogy_stmt_ok_packet_t *out_packet)
+{
+    int rc;
+
+    trilogy_reader_t reader = TRILOGY_READER(buff, len);
+
+    // skip packet type
+    CHECKED(trilogy_reader_get_uint8(&reader, NULL));
+
+    CHECKED(trilogy_reader_get_uint32(&reader, &out_packet->id));
+
+    CHECKED(trilogy_reader_get_uint16(&reader, &out_packet->column_count));
+
+    CHECKED(trilogy_reader_get_uint16(&reader, &out_packet->parameter_count));
+
+    uint8_t filler;
+
+    CHECKED(trilogy_reader_get_uint8(&reader, &filler));
+
+    if (filler != 0) {
+        return TRILOGY_PROTOCOL_VIOLATION;
+    }
+
+    CHECKED(trilogy_reader_get_uint16(&reader, &out_packet->warning_count));
+
+    return trilogy_reader_finish(&reader);
+
+fail:
+    return rc;
+}
+
 static void trilogy_pack_scramble_native_hash(const char *scramble, const char *password, size_t password_len,
                                               uint8_t *buffer, unsigned int *buffer_len)
 {
@@ -668,6 +705,456 @@ int trilogy_build_ssl_request_packet(trilogy_builder_t *builder, TRILOGY_CAPABIL
     trilogy_builder_finalize(builder);
 
     return TRILOGY_OK;
+
+fail:
+    return rc;
+}
+
+int trilogy_build_stmt_prepare_packet(trilogy_builder_t *builder, const char *sql, size_t sql_len)
+{
+    int rc = TRILOGY_OK;
+
+    CHECKED(trilogy_builder_write_uint8(builder, TRILOGY_CMD_STMT_PREPARE));
+
+    CHECKED(trilogy_builder_write_buffer(builder, sql, sql_len));
+
+    trilogy_builder_finalize(builder);
+
+    return TRILOGY_OK;
+
+fail:
+    return rc;
+}
+
+int trilogy_build_stmt_execute_packet(trilogy_builder_t *builder, uint32_t stmt_id, uint8_t flags,
+                                      trilogy_binary_value_t *binds, uint16_t num_binds)
+{
+    int rc = TRILOGY_OK;
+
+    CHECKED(trilogy_builder_write_uint8(builder, TRILOGY_CMD_STMT_EXECUTE));
+
+    CHECKED(trilogy_builder_write_uint32(builder, stmt_id));
+
+    CHECKED(trilogy_builder_write_uint8(builder, flags));
+
+    // apparently, iteration-count is always 1
+    CHECKED(trilogy_builder_write_uint32(builder, 1));
+
+    int i;
+
+    if (num_binds > 0) {
+        if (binds == NULL) {
+            return TRILOGY_PROTOCOL_VIOLATION;
+        }
+
+        int bind_off = 0;
+        int bm_bytes = (num_binds + 7) / 8;
+
+        for (i = 0; i < bm_bytes; i++) {
+            uint8_t nb = 0;
+
+            for (; bind_off < num_binds; bind_off++) {
+                if (binds[bind_off].is_null) {
+                    nb |= (bind_off % 8);
+                }
+            }
+
+            CHECKED(trilogy_builder_write_uint8(builder, nb));
+        }
+
+        // new params bound flag
+        CHECKED(trilogy_builder_write_uint8(builder, 0x1));
+
+        for (i = 0; i < num_binds; i++) {
+            CHECKED(trilogy_builder_write_uint8(builder, binds[i].type));
+            CHECKED(trilogy_builder_write_uint8(builder, 0x0));
+        }
+
+        for (i = 0; i < num_binds; i++) {
+            trilogy_binary_value_t val = binds[i];
+
+            switch (val.type) {
+            case TRILOGY_TYPE_TINY:
+                CHECKED(trilogy_builder_write_uint8(builder, val.as.uint8));
+
+                break;
+            case TRILOGY_TYPE_YEAR:
+            case TRILOGY_TYPE_SHORT:
+                CHECKED(trilogy_builder_write_uint16(builder, val.as.uint16));
+
+                break;
+            case TRILOGY_TYPE_INT24:
+            case TRILOGY_TYPE_LONG:
+                CHECKED(trilogy_builder_write_uint32(builder, val.as.uint32));
+
+                break;
+            case TRILOGY_TYPE_LONGLONG:
+                CHECKED(trilogy_builder_write_uint64(builder, val.as.uint64));
+
+                break;
+            case TRILOGY_TYPE_FLOAT:
+                CHECKED(trilogy_builder_write_float(builder, val.as.flt));
+
+                break;
+            case TRILOGY_TYPE_DOUBLE:
+                CHECKED(trilogy_builder_write_double(builder, val.as.dbl));
+
+                break;
+            case TRILOGY_TYPE_TIME: {
+                uint8_t field_len = 0;
+
+                if (val.as.date.time.micro_seconds) {
+                    field_len = 12;
+                } else if (val.as.date.time.hour || val.as.date.time.minute || val.as.date.time.second) {
+                    field_len = 8;
+                } else {
+                    field_len = 0;
+                }
+
+                CHECKED(trilogy_builder_write_uint8(builder, field_len));
+
+                if (field_len > 0) {
+                    CHECKED(trilogy_builder_write_uint8(builder, val.as.date.time.is_negative));
+
+                    CHECKED(trilogy_builder_write_uint32(builder, val.as.date.time.days));
+
+                    CHECKED(trilogy_builder_write_uint8(builder, val.as.date.time.hour));
+
+                    CHECKED(trilogy_builder_write_uint8(builder, val.as.date.time.minute));
+
+                    CHECKED(trilogy_builder_write_uint8(builder, val.as.date.time.second));
+
+                    if (field_len > 8) {
+                        CHECKED(trilogy_builder_write_uint32(builder, val.as.date.time.micro_seconds));
+                    }
+                }
+
+                break;
+            }
+            case TRILOGY_TYPE_DATE:
+            case TRILOGY_TYPE_DATETIME:
+            case TRILOGY_TYPE_TIMESTAMP: {
+                uint8_t field_len = 0;
+
+                if (val.as.date.time.micro_seconds) {
+                    field_len = 11;
+                } else if (val.as.date.time.hour || val.as.date.time.minute || val.as.date.time.second) {
+                    field_len = 7;
+                } else if (val.as.date.year || val.as.date.month || val.as.date.day) {
+                    field_len = 4;
+                } else {
+                    field_len = 0;
+                }
+
+                CHECKED(trilogy_builder_write_uint8(builder, field_len));
+
+                if (field_len > 0) {
+                    CHECKED(trilogy_builder_write_uint16(builder, val.as.date.year));
+
+                    CHECKED(trilogy_builder_write_uint8(builder, val.as.date.month));
+
+                    CHECKED(trilogy_builder_write_uint8(builder, val.as.date.day));
+
+                    if (field_len > 4) {
+                        CHECKED(trilogy_builder_write_uint8(builder, val.as.date.time.hour));
+
+                        CHECKED(trilogy_builder_write_uint8(builder, val.as.date.time.minute));
+
+                        CHECKED(trilogy_builder_write_uint8(builder, val.as.date.time.second));
+
+                        if (field_len > 7) {
+                            CHECKED(trilogy_builder_write_uint32(builder, val.as.date.time.micro_seconds));
+                        }
+                    }
+                }
+
+                break;
+            }
+            case TRILOGY_TYPE_DECIMAL:
+            case TRILOGY_TYPE_VARCHAR:
+            case TRILOGY_TYPE_BIT:
+            case TRILOGY_TYPE_NEWDECIMAL:
+            case TRILOGY_TYPE_ENUM:
+            case TRILOGY_TYPE_SET:
+            case TRILOGY_TYPE_TINY_BLOB:
+            case TRILOGY_TYPE_BLOB:
+            case TRILOGY_TYPE_MEDIUM_BLOB:
+            case TRILOGY_TYPE_LONG_BLOB:
+            case TRILOGY_TYPE_VAR_STRING:
+            case TRILOGY_TYPE_STRING:
+            case TRILOGY_TYPE_GEOMETRY:
+                CHECKED(trilogy_builder_write_lenenc_buffer(builder, val.as.str.data, val.as.str.len));
+
+                break;
+            case TRILOGY_TYPE_NULL:
+                // already handled by the null bitmap
+                break;
+            default:
+                return TRILOGY_UNKNOWN_TYPE;
+            }
+        }
+    }
+
+    trilogy_builder_finalize(builder);
+
+    return TRILOGY_OK;
+
+fail:
+    return rc;
+}
+
+int trilogy_build_stmt_bind_data_packet(trilogy_builder_t *builder, uint32_t stmt_id, uint16_t param_id, uint8_t *data,
+                                        size_t data_len)
+{
+    int rc = TRILOGY_OK;
+
+    CHECKED(trilogy_builder_write_uint8(builder, TRILOGY_CMD_STMT_SEND_LONG_DATA));
+
+    CHECKED(trilogy_builder_write_uint32(builder, stmt_id));
+
+    CHECKED(trilogy_builder_write_uint16(builder, param_id));
+
+    CHECKED(trilogy_builder_write_buffer(builder, data, data_len));
+
+    trilogy_builder_finalize(builder);
+
+    return TRILOGY_OK;
+
+fail:
+    return rc;
+}
+
+int trilogy_build_stmt_reset_packet(trilogy_builder_t *builder, uint32_t stmt_id)
+{
+    int rc = TRILOGY_OK;
+
+    CHECKED(trilogy_builder_write_uint8(builder, TRILOGY_CMD_STMT_RESET));
+
+    CHECKED(trilogy_builder_write_uint32(builder, stmt_id));
+
+    trilogy_builder_finalize(builder);
+
+    return TRILOGY_OK;
+
+fail:
+    return rc;
+}
+
+int trilogy_build_stmt_close_packet(trilogy_builder_t *builder, uint32_t stmt_id)
+{
+    int rc = TRILOGY_OK;
+
+    CHECKED(trilogy_builder_write_uint8(builder, TRILOGY_CMD_STMT_CLOSE));
+
+    CHECKED(trilogy_builder_write_uint32(builder, stmt_id));
+
+    trilogy_builder_finalize(builder);
+
+    return TRILOGY_OK;
+
+fail:
+    return rc;
+}
+
+static inline int is_null(uint8_t *null_bitmap, uint64_t bitmap_len, uint64_t column_offset, bool *col_is_null)
+{
+    if (column_offset > (bitmap_len * 8) - 1) {
+        return TRILOGY_PROTOCOL_VIOLATION;
+    }
+
+    column_offset += 2;
+
+    uint64_t byte_offset = column_offset / 8;
+
+    // for the binary protocol result row packet, we need to offset the bit check
+    // by 2
+    *col_is_null = (null_bitmap[byte_offset] & (1 << (column_offset % 8))) != 0;
+
+    return TRILOGY_OK;
+}
+
+int trilogy_parse_stmt_row_packet(const uint8_t *buff, size_t len, trilogy_column_packet_t *columns,
+                                  uint64_t column_count, trilogy_binary_value_t *out_values)
+{
+    int rc;
+
+    trilogy_reader_t reader = TRILOGY_READER(buff, len);
+
+    // skip packet header
+    CHECKED(trilogy_reader_get_uint8(&reader, NULL));
+
+    uint8_t *null_bitmap = NULL;
+    uint64_t bitmap_len = (column_count + 7 + 2) / 8;
+
+    CHECKED(trilogy_reader_get_buffer(&reader, bitmap_len, (const void **)&null_bitmap));
+
+    for (uint64_t i = 0; i < column_count; i++) {
+        CHECKED(is_null(null_bitmap, bitmap_len, i, &out_values[i].is_null));
+        if (out_values[i].is_null) {
+            out_values[i].type = TRILOGY_TYPE_NULL;
+        } else {
+            out_values[i].is_null = false;
+
+            out_values[i].type = columns[i].type;
+
+            switch (columns[i].type) {
+            case TRILOGY_TYPE_STRING:
+            case TRILOGY_TYPE_VARCHAR:
+            case TRILOGY_TYPE_VAR_STRING:
+            case TRILOGY_TYPE_ENUM:
+            case TRILOGY_TYPE_SET:
+            case TRILOGY_TYPE_LONG_BLOB:
+            case TRILOGY_TYPE_MEDIUM_BLOB:
+            case TRILOGY_TYPE_BLOB:
+            case TRILOGY_TYPE_TINY_BLOB:
+            case TRILOGY_TYPE_GEOMETRY:
+            case TRILOGY_TYPE_BIT:
+            case TRILOGY_TYPE_DECIMAL:
+            case TRILOGY_TYPE_NEWDECIMAL:
+            case TRILOGY_TYPE_JSON:
+                CHECKED(trilogy_reader_get_lenenc_buffer(&reader, &out_values[i].as.str.len,
+                                                      (const void **)&out_values[i].as.str.data));
+
+                break;
+            case TRILOGY_TYPE_LONGLONG:
+                CHECKED(trilogy_reader_get_uint64(&reader, &out_values[i].as.uint64));
+
+                break;
+            case TRILOGY_TYPE_DOUBLE:
+                CHECKED(trilogy_reader_get_double(&reader, &out_values[i].as.dbl));
+
+                break;
+            case TRILOGY_TYPE_LONG:
+            case TRILOGY_TYPE_INT24:
+                CHECKED(trilogy_reader_get_uint32(&reader, &out_values[i].as.uint32));
+
+                break;
+            case TRILOGY_TYPE_FLOAT:
+                CHECKED(trilogy_reader_get_float(&reader, &out_values[i].as.flt));
+
+                break;
+            case TRILOGY_TYPE_SHORT:
+                CHECKED(trilogy_reader_get_uint16(&reader, &out_values[i].as.uint16));
+
+                break;
+            case TRILOGY_TYPE_YEAR:
+                CHECKED(trilogy_reader_get_uint16(&reader, &out_values[i].as.date.year));
+
+                break;
+            case TRILOGY_TYPE_TINY:
+                CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.uint8));
+
+                break;
+            case TRILOGY_TYPE_DATE:
+            case TRILOGY_TYPE_DATETIME:
+            case TRILOGY_TYPE_TIMESTAMP: {
+                uint8_t time_len;
+
+                CHECKED(trilogy_reader_get_uint8(&reader, &time_len));
+
+                out_values[i].as.date.year = 0;
+                out_values[i].as.date.month = 0;
+                out_values[i].as.date.day = 0;
+                out_values[i].as.date.time.hour = 0;
+                out_values[i].as.date.time.minute = 0;
+                out_values[i].as.date.time.second = 0;
+                out_values[i].as.date.time.micro_seconds = 0;
+
+                switch (time_len) {
+                case 0:
+                    break;
+                case 4:
+                    CHECKED(trilogy_reader_get_uint16(&reader, &out_values[i].as.date.year));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.month));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.day));
+
+                    break;
+                case 7:
+                    CHECKED(trilogy_reader_get_uint16(&reader, &out_values[i].as.date.year));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.month));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.day));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.time.hour));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.time.minute));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.time.second));
+
+                    break;
+                case 11:
+                    CHECKED(trilogy_reader_get_uint16(&reader, &out_values[i].as.date.year));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.month));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.day));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.time.hour));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.time.minute));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.time.second));
+                    CHECKED(trilogy_reader_get_uint32(&reader, &out_values[i].as.date.time.micro_seconds));
+
+                    break;
+                default:
+                    return TRILOGY_PROTOCOL_VIOLATION;
+                }
+
+                break;
+            }
+            case TRILOGY_TYPE_TIME: {
+                uint8_t time_len;
+
+                CHECKED(trilogy_reader_get_uint8(&reader, &time_len));
+
+                out_values[i].as.date.time.is_negative = false;
+                out_values[i].as.date.time.days = 0;
+                out_values[i].as.date.time.hour = 0;
+                out_values[i].as.date.time.minute = 0;
+                out_values[i].as.date.time.second = 0;
+                out_values[i].as.date.time.micro_seconds = 0;
+
+                switch (time_len) {
+                case 0:
+                    break;
+                case 8: {
+                    uint8_t is_negative;
+
+                    CHECKED(trilogy_reader_get_uint8(&reader, &is_negative));
+
+                    out_values[i].as.date.time.is_negative = is_negative == 1;
+
+                    CHECKED(trilogy_reader_get_uint32(&reader, &out_values[i].as.date.time.days));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.time.hour));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.time.minute));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.time.second));
+                    CHECKED(trilogy_reader_get_uint32(&reader, &out_values[i].as.date.time.micro_seconds));
+
+                    break;
+                }
+                case 12: {
+                    uint8_t is_negative;
+
+                    CHECKED(trilogy_reader_get_uint8(&reader, &is_negative));
+
+                    out_values[i].as.date.time.is_negative = is_negative == 1;
+
+                    CHECKED(trilogy_reader_get_uint32(&reader, &out_values[i].as.date.time.days));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.time.hour));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.time.minute));
+                    CHECKED(trilogy_reader_get_uint8(&reader, &out_values[i].as.date.time.second));
+                    CHECKED(trilogy_reader_get_uint32(&reader, &out_values[i].as.date.time.micro_seconds));
+
+                    break;
+                }
+                default:
+                    return TRILOGY_PROTOCOL_VIOLATION;
+                }
+
+                break;
+            }
+            case TRILOGY_TYPE_NULL:
+            default:
+                // we cover TRILOGY_TYPE_NULL here because we should never hit this case
+                // explicitly as it should be covered in the null bitmap
+                return TRILOGY_UNKNOWN_TYPE;
+            }
+        }
+    }
+
+    return trilogy_reader_finish(&reader);
 
 fail:
     return rc;

--- a/src/reader.c
+++ b/src/reader.c
@@ -95,6 +95,48 @@ int trilogy_reader_get_uint64(trilogy_reader_t *reader, uint64_t *out)
     return TRILOGY_OK;
 }
 
+typedef union {
+    float f;
+    uint32_t u;
+} trilogy_float_buf_t;
+
+int trilogy_reader_get_float(trilogy_reader_t *reader, float *out)
+{
+    CHECK(4);
+
+    trilogy_float_buf_t float_val;
+
+    int rc = trilogy_reader_get_uint32(reader, &float_val.u);
+    if (rc != TRILOGY_OK) {
+        return rc;
+    }
+
+    *out = float_val.f;
+
+    return TRILOGY_OK;
+}
+
+typedef union {
+    double d;
+    uint64_t u;
+} trilogy_double_buf_t;
+
+int trilogy_reader_get_double(trilogy_reader_t *reader, double *out)
+{
+    CHECK(8);
+
+    trilogy_double_buf_t double_val;
+
+    int rc = trilogy_reader_get_uint64(reader, &double_val.u);
+    if (rc != TRILOGY_OK) {
+        return rc;
+    }
+
+    *out = double_val.d;
+
+    return TRILOGY_OK;
+}
+
 int trilogy_reader_get_lenenc(trilogy_reader_t *reader, uint64_t *out)
 {
     CHECK(1);

--- a/test/client/stmt_close_test.c
+++ b/test/client/stmt_close_test.c
@@ -1,0 +1,163 @@
+#include <errno.h>
+#include <poll.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../test.h"
+
+#include "trilogy/blocking.h"
+#include "trilogy/client.h"
+#include "trilogy/error.h"
+
+#define do_connect(CONN)                                                                                               \
+    do {                                                                                                               \
+        int err = trilogy_init(CONN);                                                                                  \
+        ASSERT_OK(err);                                                                                                \
+        err = trilogy_connect(CONN, get_connopt());                                                                    \
+        ASSERT_OK(err);                                                                                                \
+    } while (0)
+
+TEST test_stmt_close_send()
+{
+    trilogy_conn_t conn;
+
+    do_connect(&conn);
+
+    const char *sql = "SELECT ?";
+    size_t sql_len = strlen(sql);
+
+    int err = trilogy_stmt_prepare_send(&conn, sql, sql_len);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_writable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_flush_writes(&conn);
+    }
+    ASSERT_OK(err);
+
+    trilogy_stmt_t stmt;
+
+    err = trilogy_stmt_prepare_recv(&conn, &stmt);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_readable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_stmt_prepare_recv(&conn, &stmt);
+    }
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, stmt.parameter_count);
+
+    trilogy_column_packet_t params[1];
+
+    for (uint64_t i = 0; i < stmt.parameter_count; i++) {
+        trilogy_column_packet_t *param = &params[i];
+
+        err = trilogy_read_full_column(&conn, param);
+
+        if (err < 0) {
+            return err;
+        }
+    }
+
+    ASSERT_EQ(1, stmt.column_count);
+
+    trilogy_column_packet_t column_defs[1];
+
+    for (uint64_t i = 0; i < stmt.column_count; i++) {
+        trilogy_column_packet_t *column = &column_defs[i];
+
+        err = trilogy_read_full_column(&conn, column);
+
+        if (err < 0) {
+            return err;
+        }
+    }
+
+    err = trilogy_stmt_close_send(&conn, &stmt);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_writable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_flush_writes(&conn);
+    }
+    ASSERT_OK(err);
+
+    trilogy_free(&conn);
+    PASS();
+}
+
+TEST test_stmt_close_send_closed_socket()
+{
+    trilogy_conn_t conn;
+
+    do_connect(&conn);
+
+    const char *sql = "SELECT ?";
+    size_t sql_len = strlen(sql);
+
+    int err = trilogy_stmt_prepare_send(&conn, sql, sql_len);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_writable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_flush_writes(&conn);
+    }
+    ASSERT_OK(err);
+
+    trilogy_stmt_t stmt;
+
+    err = trilogy_stmt_prepare_recv(&conn, &stmt);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_readable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_stmt_prepare_recv(&conn, &stmt);
+    }
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, stmt.parameter_count);
+
+    trilogy_column_packet_t params[1];
+
+    for (uint64_t i = 0; i < stmt.parameter_count; i++) {
+        trilogy_column_packet_t *param = &params[i];
+
+        err = trilogy_read_full_column(&conn, param);
+
+        if (err < 0) {
+            return err;
+        }
+    }
+
+    ASSERT_EQ(1, stmt.column_count);
+
+    trilogy_column_packet_t column_defs[1];
+
+    for (uint64_t i = 0; i < stmt.column_count; i++) {
+        trilogy_column_packet_t *column = &column_defs[i];
+
+        err = trilogy_read_full_column(&conn, column);
+
+        if (err < 0) {
+            return err;
+        }
+    }
+
+    close_socket(&conn);
+
+    err = trilogy_stmt_close_send(&conn, &stmt);
+    ASSERT_ERR(TRILOGY_SYSERR, err);
+
+    trilogy_free(&conn);
+    PASS();
+}
+
+int client_stmt_close_test()
+{
+    RUN_TEST(test_stmt_close_send);
+    RUN_TEST(test_stmt_close_send_closed_socket);
+
+    return 0;
+}

--- a/test/client/stmt_execute_test.c
+++ b/test/client/stmt_execute_test.c
@@ -1,0 +1,376 @@
+#include <errno.h>
+#include <poll.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../test.h"
+
+#include "trilogy/blocking.h"
+#include "trilogy/client.h"
+#include "trilogy/error.h"
+
+#define do_connect(CONN)                                                                                               \
+    do {                                                                                                               \
+        int err = trilogy_init(CONN);                                                                                  \
+        ASSERT_OK(err);                                                                                                \
+        err = trilogy_connect(CONN, get_connopt());                                                                    \
+        ASSERT_OK(err);                                                                                                \
+    } while (0)
+
+TEST test_stmt_execute_send()
+{
+    trilogy_conn_t conn;
+
+    do_connect(&conn);
+
+    const char *sql = "SELECT ?";
+    size_t sql_len = strlen(sql);
+
+    int err = trilogy_stmt_prepare_send(&conn, sql, sql_len);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_writable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_flush_writes(&conn);
+    }
+    ASSERT_OK(err);
+
+    trilogy_stmt_t stmt;
+
+    err = trilogy_stmt_prepare_recv(&conn, &stmt);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_readable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_stmt_prepare_recv(&conn, &stmt);
+    }
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, stmt.parameter_count);
+
+    trilogy_column_packet_t params[1];
+
+    for (uint64_t i = 0; i < stmt.parameter_count; i++) {
+        trilogy_column_packet_t *param = &params[i];
+
+        err = trilogy_read_full_column(&conn, param);
+
+        if (err < 0) {
+            return err;
+        }
+    }
+
+    ASSERT_EQ(1, stmt.column_count);
+
+    trilogy_column_packet_t column_defs[1];
+
+    for (uint64_t i = 0; i < stmt.column_count; i++) {
+        trilogy_column_packet_t *column = &column_defs[i];
+
+        err = trilogy_read_full_column(&conn, column);
+
+        if (err < 0) {
+            return err;
+        }
+    }
+
+    uint8_t flags = 0x00;
+    const char str[] = {'t','e','s','t'};
+    size_t len = sizeof(str);
+    trilogy_binary_value_t binds[] = {
+        {.is_null = false, .type = TRILOGY_TYPE_VAR_STRING, .as.str.data = str, .as.str.len = len}};
+
+    err = trilogy_stmt_execute_send(&conn, &stmt, flags, binds);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_writable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_flush_writes(&conn);
+    }
+    ASSERT_OK(err);
+
+    trilogy_free(&conn);
+    PASS();
+}
+
+TEST test_stmt_execute_send_closed_socket()
+{
+    trilogy_conn_t conn;
+
+    do_connect(&conn);
+
+    const char *sql = "SELECT ?";
+    size_t sql_len = strlen(sql);
+
+    int err = trilogy_stmt_prepare_send(&conn, sql, sql_len);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_writable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_flush_writes(&conn);
+    }
+    ASSERT_OK(err);
+
+    trilogy_stmt_t stmt;
+
+    err = trilogy_stmt_prepare_recv(&conn, &stmt);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_readable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_stmt_prepare_recv(&conn, &stmt);
+    }
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, stmt.parameter_count);
+
+    trilogy_column_packet_t params[1];
+
+    for (uint64_t i = 0; i < stmt.parameter_count; i++) {
+        trilogy_column_packet_t *param = &params[i];
+
+        err = trilogy_read_full_column(&conn, param);
+
+        if (err < 0) {
+            return err;
+        }
+    }
+
+    ASSERT_EQ(1, stmt.column_count);
+
+    trilogy_column_packet_t column_defs[1];
+
+    for (uint64_t i = 0; i < stmt.column_count; i++) {
+        trilogy_column_packet_t *column = &column_defs[i];
+
+        err = trilogy_read_full_column(&conn, column);
+
+        if (err < 0) {
+            return err;
+        }
+    }
+
+    close_socket(&conn);
+
+    uint8_t flags = 0x00;
+    const char str[] = {'t', 'e', 's', 't'};
+    size_t len = sizeof(str);
+    trilogy_binary_value_t binds[] = {
+        {.is_null = false, .type = TRILOGY_TYPE_VAR_STRING, .as.str.data = str, .as.str.len = len}};
+
+    err = trilogy_stmt_execute_send(&conn, &stmt, flags, binds);
+    ASSERT_ERR(TRILOGY_SYSERR, err);
+
+    trilogy_free(&conn);
+    PASS();
+}
+
+TEST test_stmt_execute_recv()
+{
+    trilogy_conn_t conn;
+
+    do_connect(&conn);
+
+    const char *sql = "SELECT ?";
+    size_t sql_len = strlen(sql);
+
+    int err = trilogy_stmt_prepare_send(&conn, sql, sql_len);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_writable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_flush_writes(&conn);
+    }
+    ASSERT_OK(err);
+
+    trilogy_stmt_t stmt;
+
+    err = trilogy_stmt_prepare_recv(&conn, &stmt);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_readable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_stmt_prepare_recv(&conn, &stmt);
+    }
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, stmt.parameter_count);
+
+    trilogy_column_packet_t params[1];
+
+    for (uint64_t i = 0; i < stmt.parameter_count; i++) {
+        trilogy_column_packet_t *param = &params[i];
+
+        err = trilogy_read_full_column(&conn, param);
+
+        if (err < 0) {
+            return err;
+        }
+    }
+
+    ASSERT_EQ(1, stmt.column_count);
+
+    trilogy_column_packet_t column_defs[1];
+
+    for (uint64_t i = 0; i < stmt.column_count; i++) {
+        trilogy_column_packet_t *column = &column_defs[i];
+
+        err = trilogy_read_full_column(&conn, column);
+
+        if (err < 0) {
+            return err;
+        }
+    }
+
+    uint8_t flags = 0x00;
+    const char str[] = {'t', 'e', 's', 't'};
+    size_t len = sizeof(str);
+    trilogy_binary_value_t binds[] = {
+        {.is_null = false, .type = TRILOGY_TYPE_VAR_STRING, .as.str.data = str, .as.str.len = len}};
+
+    err = trilogy_stmt_execute_send(&conn, &stmt, flags, binds);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_writable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_flush_writes(&conn);
+    }
+    ASSERT_OK(err);
+
+    uint64_t column_count;
+
+    err = trilogy_stmt_execute_recv(&conn, &column_count);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_readable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_stmt_execute_recv(&conn, &column_count);
+    }
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, column_count);
+
+    trilogy_column_packet_t columns[1];
+
+    for (uint64_t i = 0; i < column_count; i++) {
+        trilogy_column_packet_t *column = &columns[i];
+
+        err = trilogy_read_full_column(&conn, column);
+
+        if (err < 0) {
+            return err;
+        }
+    }
+
+    trilogy_binary_value_t values[1];
+
+    err = trilogy_stmt_read_full_row(&conn, &stmt, columns, values);
+    ASSERT_OK(err);
+
+    ASSERT_MEM_EQ(values[0].as.str.data, "test", values[0].as.str.len);
+
+    err = trilogy_stmt_read_full_row(&conn, &stmt, columns, values);
+    ASSERT_EOF(err);
+
+    trilogy_free(&conn);
+    PASS();
+}
+
+TEST test_stmt_execute_recv_closed_socket()
+{
+
+    trilogy_conn_t conn;
+
+    do_connect(&conn);
+
+    const char *sql = "SELECT ?";
+    size_t sql_len = strlen(sql);
+
+    int err = trilogy_stmt_prepare_send(&conn, sql, sql_len);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_writable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_flush_writes(&conn);
+    }
+    ASSERT_OK(err);
+
+    trilogy_stmt_t stmt;
+
+    err = trilogy_stmt_prepare_recv(&conn, &stmt);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_readable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_stmt_prepare_recv(&conn, &stmt);
+    }
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, stmt.parameter_count);
+
+    trilogy_column_packet_t params[1];
+
+    for (uint64_t i = 0; i < stmt.parameter_count; i++) {
+        trilogy_column_packet_t *param = &params[i];
+
+        err = trilogy_read_full_column(&conn, param);
+
+        if (err < 0) {
+            free(params);
+
+            return err;
+        }
+    }
+
+    ASSERT_EQ(1, stmt.column_count);
+
+    trilogy_column_packet_t column_defs[1];
+
+    for (uint64_t i = 0; i < stmt.column_count; i++) {
+        trilogy_column_packet_t *column = &column_defs[i];
+
+        err = trilogy_read_full_column(&conn, column);
+
+        if (err < 0) {
+            free(column_defs);
+
+            return err;
+        }
+    }
+
+    uint8_t flags = 0x00;
+    const char str[] = {'t', 'e', 's', 't'};
+    size_t len = sizeof(str);
+    trilogy_binary_value_t binds[] = {
+        {.is_null = false, .type = TRILOGY_TYPE_VAR_STRING, .as.str.data = str, .as.str.len = len}};
+
+    err = trilogy_stmt_execute_send(&conn, &stmt, flags, binds);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_writable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_flush_writes(&conn);
+    }
+    ASSERT_OK(err);
+
+    close_socket(&conn);
+
+    uint64_t column_count;
+
+    err = trilogy_stmt_execute_recv(&conn, &column_count);
+    ASSERT_ERR(TRILOGY_SYSERR, err);
+
+    trilogy_free(&conn);
+    PASS();
+}
+
+int client_stmt_execute_test()
+{
+    RUN_TEST(test_stmt_execute_send);
+    RUN_TEST(test_stmt_execute_send_closed_socket);
+    RUN_TEST(test_stmt_execute_recv);
+    RUN_TEST(test_stmt_execute_recv_closed_socket);
+
+    return 0;
+}

--- a/test/client/stmt_prepare_test.c
+++ b/test/client/stmt_prepare_test.c
@@ -1,0 +1,159 @@
+#include <errno.h>
+#include <poll.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../test.h"
+
+#include "trilogy/blocking.h"
+#include "trilogy/client.h"
+#include "trilogy/error.h"
+
+#define do_connect(CONN)                                                                                               \
+    do {                                                                                                               \
+        int err = trilogy_init(CONN);                                                                                  \
+        ASSERT_OK(err);                                                                                                \
+        err = trilogy_connect(CONN, get_connopt());                                                                    \
+        ASSERT_OK(err);                                                                                                \
+    } while (0)
+
+TEST test_stmt_prepare_send()
+{
+    trilogy_conn_t conn;
+
+    do_connect(&conn);
+
+    const char *sql = "SELECT ?";
+    size_t sql_len = strlen(sql);
+
+    int err = trilogy_stmt_prepare_send(&conn, sql, sql_len);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_writable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_flush_writes(&conn);
+    }
+    ASSERT_OK(err);
+
+    trilogy_free(&conn);
+    PASS();
+}
+
+TEST test_stmt_prepare_send_closed_socket()
+{
+    trilogy_conn_t conn;
+
+    do_connect(&conn);
+
+    close_socket(&conn);
+
+    const char *sql = "SELECT ?";
+    size_t sql_len = strlen(sql);
+
+    int err = trilogy_stmt_prepare_send(&conn, sql, sql_len);
+    ASSERT_ERR(TRILOGY_SYSERR, err);
+
+    trilogy_free(&conn);
+    PASS();
+}
+
+TEST test_stmt_prepare_recv()
+{
+    trilogy_conn_t conn;
+
+    do_connect(&conn);
+
+    const char *sql = "SELECT ?";
+    size_t sql_len = strlen(sql);
+
+    int err = trilogy_stmt_prepare_send(&conn, sql, sql_len);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_writable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_flush_writes(&conn);
+    }
+    ASSERT_OK(err);
+
+    trilogy_stmt_t stmt;
+
+    err = trilogy_stmt_prepare_recv(&conn, &stmt);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_readable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_stmt_prepare_recv(&conn, &stmt);
+    }
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, stmt.parameter_count);
+
+    trilogy_column_packet_t params[1];
+
+    for (uint64_t i = 0; i < stmt.parameter_count; i++) {
+        trilogy_column_packet_t *param = &params[i];
+
+        err = trilogy_read_full_column(&conn, param);
+
+        if (err < 0) {
+            return err;
+        }
+    }
+
+    ASSERT_EQ(1, stmt.column_count);
+
+    trilogy_column_packet_t column_defs[1];
+
+    for (uint64_t i = 0; i < stmt.column_count; i++) {
+        trilogy_column_packet_t *column = &column_defs[i];
+
+        err = trilogy_read_full_column(&conn, column);
+
+        if (err < 0) {
+            return err;
+        }
+    }
+
+    trilogy_free(&conn);
+    PASS();
+}
+
+TEST test_stmt_prepare_recv_closed_socket()
+{
+    trilogy_conn_t conn;
+
+    do_connect(&conn);
+
+    const char *sql = "SELECT ?";
+    size_t sql_len = strlen(sql);
+
+    int err = trilogy_stmt_prepare_send(&conn, sql, sql_len);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_writable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_flush_writes(&conn);
+    }
+    ASSERT_OK(err);
+
+    close_socket(&conn);
+
+    trilogy_stmt_t stmt;
+
+    err = trilogy_stmt_prepare_recv(&conn, &stmt);
+    ASSERT_ERR(TRILOGY_SYSERR, err);
+
+    trilogy_free(&conn);
+    PASS();
+}
+
+int client_stmt_prepare_test()
+{
+    RUN_TEST(test_stmt_prepare_send);
+    RUN_TEST(test_stmt_prepare_send_closed_socket);
+    RUN_TEST(test_stmt_prepare_recv);
+    RUN_TEST(test_stmt_prepare_recv_closed_socket);
+
+    return 0;
+}

--- a/test/client/stmt_reset_test.c
+++ b/test/client/stmt_reset_test.c
@@ -1,0 +1,319 @@
+#include <errno.h>
+#include <poll.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../test.h"
+
+#include "trilogy/blocking.h"
+#include "trilogy/client.h"
+#include "trilogy/error.h"
+
+#define do_connect(CONN)                                                                                               \
+    do {                                                                                                               \
+        int err = trilogy_init(CONN);                                                                                  \
+        ASSERT_OK(err);                                                                                                \
+        err = trilogy_connect(CONN, get_connopt());                                                                    \
+        ASSERT_OK(err);                                                                                                \
+    } while (0)
+
+TEST test_stmt_reset_send()
+{
+    trilogy_conn_t conn;
+
+    do_connect(&conn);
+
+    const char *sql = "SELECT ?";
+    size_t sql_len = strlen(sql);
+
+    int err = trilogy_stmt_prepare_send(&conn, sql, sql_len);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_writable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_flush_writes(&conn);
+    }
+    ASSERT_OK(err);
+
+    trilogy_stmt_t stmt;
+
+    err = trilogy_stmt_prepare_recv(&conn, &stmt);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_readable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_stmt_prepare_recv(&conn, &stmt);
+    }
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, stmt.parameter_count);
+
+    trilogy_column_packet_t params[1];
+
+    for (uint64_t i = 0; i < stmt.parameter_count; i++) {
+        trilogy_column_packet_t *param = &params[i];
+
+        err = trilogy_read_full_column(&conn, param);
+
+        if (err < 0) {
+            return err;
+        }
+    }
+
+    ASSERT_EQ(1, stmt.column_count);
+
+    trilogy_column_packet_t column_defs[1];
+
+    for (uint64_t i = 0; i < stmt.column_count; i++) {
+        trilogy_column_packet_t *column = &column_defs[i];
+
+        err = trilogy_read_full_column(&conn, column);
+
+        if (err < 0) {
+            return err;
+        }
+    }
+
+    err = trilogy_stmt_reset_send(&conn, &stmt);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_writable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_flush_writes(&conn);
+    }
+    ASSERT_OK(err);
+
+    trilogy_free(&conn);
+    PASS();
+}
+
+TEST test_stmt_reset_send_closed_socket()
+{
+    trilogy_conn_t conn;
+
+    do_connect(&conn);
+
+    const char *sql = "SELECT ?";
+    size_t sql_len = strlen(sql);
+
+    int err = trilogy_stmt_prepare_send(&conn, sql, sql_len);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_writable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_flush_writes(&conn);
+    }
+    ASSERT_OK(err);
+
+    trilogy_stmt_t stmt;
+
+    err = trilogy_stmt_prepare_recv(&conn, &stmt);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_readable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_stmt_prepare_recv(&conn, &stmt);
+    }
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, stmt.parameter_count);
+
+    trilogy_column_packet_t params[1];
+
+    for (uint64_t i = 0; i < stmt.parameter_count; i++) {
+        trilogy_column_packet_t *param = &params[i];
+
+        err = trilogy_read_full_column(&conn, param);
+
+        if (err < 0) {
+            return err;
+        }
+    }
+
+    ASSERT_EQ(1, stmt.column_count);
+
+    trilogy_column_packet_t column_defs[1];
+
+    for (uint64_t i = 0; i < stmt.column_count; i++) {
+        trilogy_column_packet_t *column = &column_defs[i];
+
+        err = trilogy_read_full_column(&conn, column);
+
+        if (err < 0) {
+            return err;
+        }
+    }
+
+    close_socket(&conn);
+
+    err = trilogy_stmt_reset_send(&conn, &stmt);
+    ASSERT_ERR(TRILOGY_SYSERR, err);
+
+    trilogy_free(&conn);
+    PASS();
+}
+
+TEST test_stmt_reset_recv()
+{
+    trilogy_conn_t conn;
+
+    do_connect(&conn);
+
+    const char *sql = "SELECT ?";
+    size_t sql_len = strlen(sql);
+
+    int err = trilogy_stmt_prepare_send(&conn, sql, sql_len);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_writable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_flush_writes(&conn);
+    }
+    ASSERT_OK(err);
+
+    trilogy_stmt_t stmt;
+
+    err = trilogy_stmt_prepare_recv(&conn, &stmt);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_readable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_stmt_prepare_recv(&conn, &stmt);
+    }
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, stmt.parameter_count);
+
+    trilogy_column_packet_t params[1];
+
+    for (uint64_t i = 0; i < stmt.parameter_count; i++) {
+        trilogy_column_packet_t *param = &params[i];
+
+        err = trilogy_read_full_column(&conn, param);
+
+        if (err < 0) {
+            return err;
+        }
+    }
+
+    ASSERT_EQ(1, stmt.column_count);
+
+    trilogy_column_packet_t column_defs[1];
+
+    for (uint64_t i = 0; i < stmt.column_count; i++) {
+        trilogy_column_packet_t *column = &column_defs[i];
+
+        err = trilogy_read_full_column(&conn, column);
+
+        if (err < 0) {
+            return err;
+        }
+    }
+
+    err = trilogy_stmt_reset_send(&conn, &stmt);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_writable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_flush_writes(&conn);
+    }
+    ASSERT_OK(err);
+
+    err = trilogy_stmt_reset_recv(&conn);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_readable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_stmt_reset_recv(&conn);
+    }
+    ASSERT_OK(err);
+
+    trilogy_free(&conn);
+    PASS();
+}
+
+TEST test_stmt_reset_recv_closed_socket()
+{
+    trilogy_conn_t conn;
+
+    do_connect(&conn);
+
+    const char *sql = "SELECT ?";
+    size_t sql_len = strlen(sql);
+
+    int err = trilogy_stmt_prepare_send(&conn, sql, sql_len);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_writable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_flush_writes(&conn);
+    }
+    ASSERT_OK(err);
+
+    trilogy_stmt_t stmt;
+
+    err = trilogy_stmt_prepare_recv(&conn, &stmt);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_readable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_stmt_prepare_recv(&conn, &stmt);
+    }
+    ASSERT_OK(err);
+
+    ASSERT_EQ(1, stmt.parameter_count);
+
+    trilogy_column_packet_t params[1];
+
+    for (uint64_t i = 0; i < stmt.parameter_count; i++) {
+        trilogy_column_packet_t *param = &params[i];
+
+        err = trilogy_read_full_column(&conn, param);
+
+        if (err < 0) {
+            return err;
+        }
+    }
+
+    ASSERT_EQ(1, stmt.column_count);
+
+    trilogy_column_packet_t column_defs[1];
+
+    for (uint64_t i = 0; i < stmt.column_count; i++) {
+        trilogy_column_packet_t *column = &column_defs[i];
+
+        err = trilogy_read_full_column(&conn, column);
+
+        if (err < 0) {
+            return err;
+        }
+    }
+
+    err = trilogy_stmt_reset_send(&conn, &stmt);
+    while (err == TRILOGY_AGAIN) {
+        err = wait_writable(&conn);
+        ASSERT_OK(err);
+
+        err = trilogy_flush_writes(&conn);
+    }
+    ASSERT_OK(err);
+
+    close_socket(&conn);
+
+    err = trilogy_stmt_reset_recv(&conn);
+    ASSERT_ERR(TRILOGY_SYSERR, err);
+
+    trilogy_free(&conn);
+    PASS();
+}
+
+int client_stmt_reset_test()
+{
+    RUN_TEST(test_stmt_reset_send);
+    RUN_TEST(test_stmt_reset_send_closed_socket);
+    RUN_TEST(test_stmt_reset_recv);
+    RUN_TEST(test_stmt_reset_recv_closed_socket);
+
+    return 0;
+}

--- a/test/protocol/building/stmt_bind_data_packet_test.c
+++ b/test/protocol/building/stmt_bind_data_packet_test.c
@@ -1,0 +1,43 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../../test.h"
+
+#include "trilogy/error.h"
+#include "trilogy/protocol.h"
+
+TEST test_stmt_bind_data_packet()
+{
+    trilogy_builder_t builder;
+    trilogy_buffer_t buff;
+
+    int err = trilogy_buffer_init(&buff, 1);
+    ASSERT_OK(err);
+
+    err = trilogy_builder_init(&builder, &buff, 0);
+    ASSERT_OK(err);
+
+    uint32_t stmt_id = 1;
+    uint32_t param_id = 2;
+    uint8_t data[] = {'d', 'a', 't', 'a'};
+    size_t data_len = sizeof(data);
+
+    err = trilogy_build_stmt_bind_data_packet(&builder, stmt_id, param_id, data, data_len);
+    ASSERT_OK(err);
+
+    static const uint8_t expected[] = {0x0b, 0x00, 0x00, 0x00, 0x18, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 'd', 'a',
+                                       't', 'a'};
+
+    ASSERT_MEM_EQ(buff.buff, expected, buff.len);
+
+    trilogy_buffer_free(&buff);
+    PASS();
+}
+
+int stmt_bind_data_packet_test()
+{
+    RUN_TEST(test_stmt_bind_data_packet);
+
+    return 0;
+}

--- a/test/protocol/building/stmt_close_packet_test.c
+++ b/test/protocol/building/stmt_close_packet_test.c
@@ -1,0 +1,39 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../../test.h"
+
+#include "trilogy/error.h"
+#include "trilogy/protocol.h"
+
+TEST test_stmt_close_packet()
+{
+    trilogy_builder_t builder;
+    trilogy_buffer_t buff;
+
+    int err = trilogy_buffer_init(&buff, 1);
+    ASSERT_OK(err);
+
+    err = trilogy_builder_init(&builder, &buff, 0);
+    ASSERT_OK(err);
+
+    uint32_t stmt_id = 1;
+
+    err = trilogy_build_stmt_close_packet(&builder, stmt_id);
+    ASSERT_OK(err);
+
+    static const uint8_t expected[] = {0x05, 0x00, 0x00, 0x00, 0x19, 0x01, 0x00, 0x00, 0x00};
+
+    ASSERT_MEM_EQ(buff.buff, expected, buff.len);
+
+    trilogy_buffer_free(&buff);
+    PASS();
+}
+
+int stmt_close_packet_test()
+{
+    RUN_TEST(test_stmt_close_packet);
+
+    return 0;
+}

--- a/test/protocol/building/stmt_execute_packet_test.c
+++ b/test/protocol/building/stmt_execute_packet_test.c
@@ -1,0 +1,43 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../../test.h"
+
+#include "trilogy/error.h"
+#include "trilogy/protocol.h"
+
+TEST test_stmt_execute_packet()
+{
+    trilogy_builder_t builder;
+    trilogy_buffer_t buff;
+
+    int err = trilogy_buffer_init(&buff, 1);
+    ASSERT_OK(err);
+
+    err = trilogy_builder_init(&builder, &buff, 0);
+    ASSERT_OK(err);
+
+    uint32_t stmt_id = 1;
+    uint8_t flags = 1;
+    trilogy_binary_value_t binds[] = {{.is_null = false, .type = TRILOGY_TYPE_LONG, .as.uint32 = 15}};
+    uint16_t num_binds = 1;
+
+    err = trilogy_build_stmt_execute_packet(&builder, stmt_id, flags, binds, num_binds);
+    ASSERT_OK(err);
+
+    static const uint8_t expected[] = {0x12, 0x00, 0x00, 0x00, 0x17, 0x01, 0x00, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00,
+                                       0x00, 0x00, 0x01, 0x03, 0x00, 0x0f, 0x00, 0x00, 0x00};
+
+    ASSERT_MEM_EQ(buff.buff, expected, buff.len);
+
+    trilogy_buffer_free(&buff);
+    PASS();
+}
+
+int stmt_execute_packet_test()
+{
+    RUN_TEST(test_stmt_execute_packet);
+
+    return 0;
+}

--- a/test/protocol/building/stmt_prepare_packet_test.c
+++ b/test/protocol/building/stmt_prepare_packet_test.c
@@ -1,0 +1,40 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../../test.h"
+
+#include "trilogy/error.h"
+#include "trilogy/protocol.h"
+
+TEST test_stmt_prepare_packet()
+{
+    trilogy_builder_t builder;
+    trilogy_buffer_t buff;
+
+    int err = trilogy_buffer_init(&buff, 1);
+    ASSERT_OK(err);
+
+    err = trilogy_builder_init(&builder, &buff, 0);
+    ASSERT_OK(err);
+
+    const char *sql = "SELECT ?";
+    size_t sql_len = strlen(sql);
+
+    err = trilogy_build_stmt_prepare_packet(&builder, sql, sql_len);
+    ASSERT_OK(err);
+
+    static const uint8_t expected[] = {0x09, 0x00, 0x00, 0x00, 0x16, 'S', 'E', 'L', 'E', 'C', 'T', ' ', '?'};
+
+    ASSERT_MEM_EQ(buff.buff, expected, buff.len);
+
+    trilogy_buffer_free(&buff);
+    PASS();
+}
+
+int stmt_prepare_packet_test()
+{
+    RUN_TEST(test_stmt_prepare_packet);
+
+    return 0;
+}

--- a/test/protocol/building/stmt_reset_packet_test.c
+++ b/test/protocol/building/stmt_reset_packet_test.c
@@ -1,0 +1,39 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../../test.h"
+
+#include "trilogy/error.h"
+#include "trilogy/protocol.h"
+
+TEST test_stmt_reset_packet()
+{
+    trilogy_builder_t builder;
+    trilogy_buffer_t buff;
+
+    int err = trilogy_buffer_init(&buff, 1);
+    ASSERT_OK(err);
+
+    err = trilogy_builder_init(&builder, &buff, 0);
+    ASSERT_OK(err);
+
+    uint32_t stmt_id = 1;
+
+    err = trilogy_build_stmt_reset_packet(&builder, stmt_id);
+    ASSERT_OK(err);
+
+    static const uint8_t expected[] = {0x05, 0x00, 0x00, 0x00, 0x1a, 0x01, 0x00, 0x00, 0x00};
+
+    ASSERT_MEM_EQ(buff.buff, expected, buff.len);
+
+    trilogy_buffer_free(&buff);
+    PASS();
+}
+
+int stmt_reset_packet_test()
+{
+    RUN_TEST(test_stmt_reset_packet);
+
+    return 0;
+}

--- a/test/runner.c
+++ b/test/runner.c
@@ -32,11 +32,20 @@ const trilogy_sockopt_t *get_connopt(void) { return &connopt; }
     SUITE(build_ping_packet_test)                                                                                      \
     SUITE(build_quit_packet_test)                                                                                      \
     SUITE(build_query_packet_test)                                                                                     \
+    SUITE(stmt_prepare_packet_test)                                                                                    \
+    SUITE(stmt_bind_data_packet_test)                                                                                  \
+    SUITE(stmt_execute_packet_test)                                                                                    \
+    SUITE(stmt_reset_packet_test)                                                                                      \
+    SUITE(stmt_close_packet_test)                                                                                      \
     SUITE(client_connect_test)                                                                                         \
     SUITE(client_escape_test)                                                                                          \
     SUITE(client_auth_test)                                                                                            \
     SUITE(client_change_db_test)                                                                                       \
-    SUITE(client_ping_test)
+    SUITE(client_ping_test)                                                                                            \
+    SUITE(client_stmt_prepare_test)                                                                                    \
+    SUITE(client_stmt_execute_test)                                                                                    \
+    SUITE(client_stmt_reset_test)                                                                                      \
+    SUITE(client_stmt_close_test)
 
 #define XX(name) extern int name();
 ALL_SUITES(XX)

--- a/test/test.h
+++ b/test/test.h
@@ -8,6 +8,7 @@
 
 #define ASSERT_ERR(EXP, GOT) ASSERT_ENUM_EQ((EXP), (GOT), trilogy_error)
 #define ASSERT_OK(GOT) ASSERT_ERR(TRILOGY_OK, (GOT))
+#define ASSERT_EOF(GOT) ASSERT_ERR(TRILOGY_EOF, (GOT))
 
 /* Helpers */
 


### PR DESCRIPTION
As the title says, this adds support for the binary protocol, which is used by prepared statements.

There's still a little bit to do here, though mainly just wrapping up docs and some cleanup and adding a few more tests. But I wanted to get this open for review sooner than later.

I figured wrapping this with the Ruby gem/extension could happen in a separate pull request, but if it makes sense to just go ahead and add here let me know.

Some of the things I'd like to wrap up before calling this done:

- [ ] Finish up writing docs
- [ ] Add tests for the blocking API
- [ ] Add more tests for edge cases
- [ ] Wrap this and expose it with the Ruby gem?

So happy to see this finally made open source.

Thank you!